### PR TITLE
Dynamic super peers feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3490,6 +3490,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchbox_hybrid_client"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "console_log",
+ "futures 0.3.31",
+ "futures-timer",
+ "log",
+ "matchbox_socket",
+ "wasm-bindgen",
+ "wasm-bindgen-futures 0.4.49",
+]
+
+[[package]]
 name = "matchbox_protocol"
 version = "0.11.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3501,6 +3501,7 @@ dependencies = [
  "matchbox_socket",
  "wasm-bindgen",
  "wasm-bindgen-futures 0.4.49",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ members = [
   "matchbox_server",
   "matchbox_signaling",
   "examples/*", 
-  "matchbox_super_client", "matchbox_server_hybrid",
+  "matchbox_super_client", "matchbox_server_hybrid", "matchbox_hybrid_client",
 ]
 resolver = "2" # Important! Bevy/WGPU needs this!

--- a/matchbox_hybrid_client/Cargo.toml
+++ b/matchbox_hybrid_client/Cargo.toml
@@ -12,6 +12,7 @@ console_log = "1.0"
 futures = { version = "0.3", default-features = false }
 wasm-bindgen-futures = "0.4.29"
 wasm-bindgen = {version = "0.2", features = ["serde-serialize"]} 
+web-sys = { version = "0.3", features = ["Window", "Navigator", "NetworkInformation", "console"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/matchbox_hybrid_client/Cargo.toml
+++ b/matchbox_hybrid_client/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "matchbox_hybrid_client"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+matchbox_socket = { path = "../matchbox_socket" }
+futures-timer = { version = "3", features = ["wasm-bindgen"] }
+log = { version = "0.4", default-features = false }
+console_error_panic_hook = "0.1.7"
+console_log = "1.0"
+futures = { version = "0.3", default-features = false }
+wasm-bindgen-futures = "0.4.29"
+wasm-bindgen = {version = "0.2", features = ["serde-serialize"]} 
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/matchbox_hybrid_client/index.html
+++ b/matchbox_hybrid_client/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Backend Peer</title>
+</head>
+<body>
+  <h1>Backend Peer</h1>
+  <script type="module">
+    // Import the initialization function and any exported functions from your package
+    import init from './pkg/matchbox_hybrid_client.js';
+
+    init().then(() => {
+        console.log("Wasm module loaded and initialized.");
+    });
+
+  </script>
+</body>
+</html>

--- a/matchbox_hybrid_client/src/lib.rs
+++ b/matchbox_hybrid_client/src/lib.rs
@@ -1,0 +1,62 @@
+use futures::{select, FutureExt};
+use futures_timer::Delay;
+use log::info;
+use matchbox_socket::{PeerState, WebRtcSocket};
+use std::time::Duration;
+use wasm_bindgen::prelude::*;
+
+const CHANNEL_ID: usize = 0;
+
+#[wasm_bindgen]
+pub fn start() {
+    // Setup logging
+    console_error_panic_hook::set_once();
+    console_log::init_with_level(log::Level::Debug).unwrap();
+
+    wasm_bindgen_futures::spawn_local(async_loop());
+}
+
+async fn async_loop() {
+    info!("Connecting to matchbox");
+    let (mut socket, loop_fut) = WebRtcSocket::new_reliable("ws://localhost:3536/");
+
+    let loop_fut = loop_fut.fuse();
+    futures::pin_mut!(loop_fut);
+
+    let timeout = Delay::new(Duration::from_millis(100));
+    futures::pin_mut!(timeout);
+
+    loop {
+        // Handle any new peers
+        for (peer, state) in socket.update_peers() {
+            match state {
+                PeerState::Connected => {
+                    info!("Peer joined: {peer}");
+                    let packet = "hello friend!".as_bytes().to_vec().into_boxed_slice();
+                    socket.channel_mut(CHANNEL_ID).send(packet, peer);
+                }
+                PeerState::Disconnected => {
+                    info!("Peer left: {peer}");
+                }
+            }
+        }
+
+        // Accept any messages incoming
+        for (peer, packet) in socket.channel_mut(CHANNEL_ID).receive() {
+            let message = String::from_utf8_lossy(&packet);
+            info!("Message from {peer}: {message:?}");
+        }
+
+        select! {
+            // Restart this loop every 100ms
+            _ = (&mut timeout).fuse() => {
+                timeout.reset(Duration::from_millis(100));
+            }
+
+            // Or break if the message loop ends (disconnected, closed, etc.)
+            _ = &mut loop_fut => {
+                break;
+            }
+        }
+    }
+}

--- a/matchbox_hybrid_client/src/lib.rs
+++ b/matchbox_hybrid_client/src/lib.rs
@@ -13,10 +13,10 @@ pub fn start() {
     console_error_panic_hook::set_once();
     console_log::init_with_level(log::Level::Debug).unwrap();
 
-    wasm_bindgen_futures::spawn_local(async_loop());
+    wasm_bindgen_futures::spawn_local(async_main());
 }
 
-async fn async_loop() {
+async fn async_main() {  
     info!("Connecting to matchbox");
     let (mut socket, loop_fut) = WebRtcSocket::new_reliable("ws://localhost:3536/");
 

--- a/matchbox_server_hybrid/Cargo.toml
+++ b/matchbox_server_hybrid/Cargo.toml
@@ -21,6 +21,7 @@ uuid = { version = "1.4", features = ["serde", "v4"] }
 clap = { version = "4.3", features = ["derive", "env"] }
 thiserror = "2.0"
 tokio-stream = "0.1"
+tokio-tungstenite = "0.24"
 
 [dev-dependencies]
 tokio-tungstenite = "0.24"

--- a/matchbox_server_hybrid/src/main.rs
+++ b/matchbox_server_hybrid/src/main.rs
@@ -38,6 +38,11 @@ async fn main() {
 
     let state = HybridState::default();
     let server = SignalingServerBuilder::new(args.host, HybridTopology, state.clone())
+        .on_connection_request(|connection| {
+            info!("Connecting: {connection:?}");
+            Ok(true) // Allow all connections
+        })
+        .on_id_assignment(|(socket, id)| info!("{socket} received {id}"))
         .cors()
         .trace()
         .mutate_router(|router| router.route("/health", get(health_handler)))

--- a/matchbox_server_hybrid/src/state.rs
+++ b/matchbox_server_hybrid/src/state.rs
@@ -5,58 +5,68 @@ use matchbox_signaling::{
     SignalingError, SignalingState,
 };
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
 use tracing::{error, info};
 
-/// Normal peer
-#[derive(Debug, Clone)]
-pub struct ChildPeer {
-    /// Peer id
+/// Enum representing whether a peer is a child or super peer (and associated data).
+#[derive(Debug)]
+pub enum PeerRole {
+    /// Child peer: stores the ID of its parent super peer, if any.
+    Child {
+        parent_id: Option<PeerId>,
+    },
+    /// Super peer: stores a set of child peers.
+    Super {
+        children: HashSet<PeerId>,
+    },
+}
+
+/// A single “Peer” type that can be either a child or super peer.
+#[derive(Debug)]
+pub struct Peer {
+    /// The peer’s unique ID.
     pub id: PeerId,
-    /// id of parent super peer
-    pub parent_id: Option<PeerId>,
-    /// Channel to communicate with signaling server
+    /// The peer’s role (child or super).
+    pub role: PeerRole,
+    /// Channel to communicate with the signaling server.
     pub signaling_channel: SignalingChannel,
 }
 
-impl ChildPeer {
-    /// Creates a new Super Peer instance
-    pub fn new(id: PeerId, signaling_channel: SignalingChannel) -> Self {
-        ChildPeer {
+impl Peer {
+    /// Create a new Peer as a Child (default role).
+    pub fn new_child(id: PeerId, signaling_channel: SignalingChannel) -> Self {
+        Peer {
             id,
-            parent_id : None,
+            role: PeerRole::Child { parent_id: None },
             signaling_channel,
-        }   
+        }
     }
-}
 
-/// Super peer
-#[derive(Debug, Clone)]
-pub struct SuperPeer {
-        /// Peer id
-        pub id: PeerId,
-        /// Set of children peers
-        pub children: StateObj<HashSet<PeerId>>,                          
-        /// Channel to communicate with signaling server
-        pub signaling_channel: SignalingChannel,
-}
-
-impl SuperPeer {
-    /// Creates a new Super Peer instance
-    pub fn new(id: PeerId, signaling_channel: SignalingChannel) -> Self {
-        SuperPeer {
+    /// Create a new Peer as a Super Peer.
+    pub fn new_super(id: PeerId, signaling_channel: SignalingChannel) -> Self {
+        Peer {
             id,
-            children: Arc::new(Mutex::new(HashSet::new())),
+            role: PeerRole::Super {
+                children: HashSet::new(),
+            },
             signaling_channel,
-        }  
+        }
+    }
+    
+    /// Returns `true` if this peer is a super peer.
+    pub fn is_super(&self) -> bool {
+        matches!(self.role, PeerRole::Super { .. })
+    }
+
+    /// Returns `true` if this peer is a child peer.
+    pub fn is_child(&self) -> bool {
+        matches!(self.role, PeerRole::Child { .. })
     }
 }
 
 /// Signaling server state for hybrid topologies
 #[derive(Default, Debug, Clone)]
 pub struct HybridState {
-    pub(crate) super_peers: StateObj<HashMap<PeerId, SuperPeer>>,
-    pub(crate) child_peers: StateObj<HashMap<PeerId, ChildPeer>>,
+    pub peers: StateObj<HashMap<PeerId, Peer>>,
 }
 impl SignalingState for HybridState {}  
 
@@ -65,23 +75,70 @@ impl HybridState {
 
     /// Get number of super peers connected
     pub fn get_num_super_peers(&self) -> usize {
-        self.super_peers.lock().unwrap().iter().len()
+        let peers = self.peers.lock().unwrap();
+        peers
+            .values()
+            .filter(|peer| matches!(peer.role, PeerRole::Super { .. }))
+            .count()
     }
 
-    /// Check if peer_id is associated with a super peer
-    pub fn is_super_peer(&self, peer: &PeerId) -> bool {
-        self.super_peers.lock()
-                        .unwrap()
-                        .contains_key(peer)
+    /// Get number of child peers connected
+    pub fn get_num_child_peers(&self) -> usize {
+        let peers = self.peers.lock().unwrap();
+        peers
+            .values()
+            .filter(|peer| matches!(peer.role, PeerRole::Child { .. }))
+            .count()
     }
 
-    /// Find optimal super peer to give child
-    pub fn find_super_peer(&mut self) -> Option<PeerId> {
-        self.super_peers.lock()
-                        .unwrap()
-                        .iter()
-                        .min_by_key(|(&id, sp)| (sp.children.lock().unwrap().len(), id))
-                        .map(|(&id, _)| id)
+    /// Check if a given `PeerId` corresponds to a super peer
+    pub fn is_super_peer(&self, peer_id: &PeerId) -> bool {
+        let peers = self.peers.lock().unwrap();
+        if let Some(peer) = peers.get(peer_id) {
+            matches!(peer.role, PeerRole::Super { .. })
+        } else {
+            false
+        }
+    }
+
+    /// Get all super peer IDs
+    pub fn get_super_peer_ids(&self) -> Vec<PeerId> {
+        self.peers
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|peer| peer.is_super())
+            .map(|peer| peer.id)
+            .collect()
+    }
+
+    /// Get all child peer IDs
+    pub fn get_child_peer_ids(&self) -> Vec<PeerId> {
+        self.peers
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|peer| peer.is_child())
+            .map(|peer| peer.id)
+            .collect()
+    }
+
+    /// Returns super peer with the least number of children then lowest ID
+    pub fn find_least_loaded_super_peer(&self) -> Option<PeerId> {
+        let peers = self.peers.lock().unwrap();
+        peers
+            .values()
+            // Filter only super peers
+            .filter(|peer| matches!(peer.role, PeerRole::Super { .. }))
+            // Among super peers, find the one with the smallest (children.len(), id)
+            .min_by_key(|peer| {
+                match &peer.role {
+                    PeerRole::Super { children } => (children.len(), peer.id),
+                    _ => (usize::MAX, peer.id), 
+                }
+            })
+            // Return the selected peer’s ID
+            .map(|peer| peer.id)
     }
 
     /// Add a new super peer
@@ -89,123 +146,216 @@ impl HybridState {
         // Alert all super peers of new super peer
         let event = Message::Text(JsonPeerEvent::NewPeer(peer).to_string());
         // Safety: Lock must be scoped/dropped to ensure no deadlock with loop
-        let super_peers = { self.super_peers.lock().unwrap().clone() };
-        super_peers.keys().for_each(|peer_id| {
-            if let Err(e) = self.try_send_to_super_peer(*peer_id, event.clone()) {
-                error!("error sending to {peer_id}: {e:?}");
+        let super_peers = { self.get_super_peer_ids()};
+
+        super_peers.iter().for_each(|peer_id| {
+            if let Err(e) = self.try_send_to_peer(*peer_id, event.clone()) {
+                error!("error informing {peer_id} of new super peer {peer}: {e:?}");
             }
         });
         // Safety: All prior locks in this method must be freed prior to this call
-        self.super_peers.lock().as_mut().unwrap().insert(peer, SuperPeer::new(peer, sender));
+        self.peers.lock().as_mut().unwrap().insert(peer, Peer::new_super(peer, sender));
     }
 
     /// Add child peer
     pub fn add_child_peer(&mut self, peer: PeerId, sender: SignalingChannel) {
-        self.child_peers.lock()
+        self.peers.lock()
                         .as_mut()
                         .unwrap()
-                        .insert(peer, ChildPeer::new(peer, sender));
+                        .insert(peer, Peer::new_child(peer, sender));
     }
 
     /// Connect child to super peer
-    pub fn connect_child(&mut self, child_peer: PeerId, super_peer: PeerId) -> Result<(), SignalingError> {
-        if let Some(sp) = self.super_peers.lock().unwrap().get(&super_peer) {
+    pub fn connect_child(&mut self, child_id: PeerId, super_id: PeerId) -> Result<(), SignalingError> {
+        {
+            let mut peers = self.peers.lock().unwrap();
             
-            sp.children.lock()
-                        .as_mut()
-                        .unwrap()
-                        .insert(child_peer);   
-        }
+            {
+                // Find the super peer in the map.
+                let super_peer = peers
+                    .get_mut(&super_id)
+                    .ok_or(SignalingError::UnknownPeer)?;
 
-        if let Some(cp) = self.child_peers.lock().unwrap().get_mut(&child_peer) {
-            cp.parent_id = Some(super_peer);
-        } 
-        
-        let event = Message::Text(JsonPeerEvent::NewPeer(child_peer).to_string());
-        
-        self.try_send_to_super_peer(super_peer, event)    
+                // Ensure the peer is actually a Super peer, then add the child to its set.
+                match &mut super_peer.role {
+                    PeerRole::Super { children } => {
+                        children.insert(child_id);
+                    }
+                    _ => {
+                        error!("Peer {super_id} is not a super peer");
+                        return Err(SignalingError::UnknownPeer); // IncorrectRole would be a better error
+                    }
+                }
+            }
+            {
+                // Find the child peer in the map.
+                let child_peer = peers
+                    .get_mut(&child_id)
+                    .ok_or(SignalingError::UnknownPeer)?;
+
+                // Ensure the peer is actually a Child, then set its parent_id.
+                match &mut child_peer.role {
+                    PeerRole::Child { parent_id } => {
+                        *parent_id = Some(super_id);
+                    }
+                    _ => {
+                        error!("Peer {child_id} is not a child peer");
+                        return Err(SignalingError::UnknownPeer); // IncorrectRole would be a better error
+                    }
+                }
+            }
+        }
+        // Safety: All prior locks in this method must be freed prior to this call
+        let event = Message::Text(JsonPeerEvent::NewPeer(child_id).to_string());
+        self.try_send_to_peer(super_id, event)
     }   
+    
+    /// Disconnect child peer from super peer
+    pub fn remove_child_peer(&mut self, child_id: PeerId) {
+        // Store the parent ID outside the lock, so we can notify them after dropping the lock.
+        let mut parent_id: Option<PeerId> = None;
+        {
+            // Lock the peers map and remove the child
+            let mut peers = self.peers.lock().unwrap();
 
-    /// Remove child peer
-    pub fn remove_child_peer(&mut self, peer: &PeerId) {
-        if let Some(cp) = self.child_peers.lock().as_mut().unwrap().remove(peer) {
-            if let Some(parent_id) = cp.parent_id {
-                let event = Message::Text(JsonPeerEvent::PeerLeft(*peer).to_string());
-                match self.try_send_to_super_peer(parent_id, event) {
-                    Ok(()) => {
-                        info!("Notified parent of child peer remove: {peer}")
-                    }
-                    Err(e) => {
-                        error!("Failure sending peer remove to parent: {e:?}")
-                    }
-                }
-                if let Some(sp) = self.super_peers.lock().unwrap().get(&parent_id) {
-                    sp.children.lock().as_mut().unwrap().remove(peer);
-                }
-            }
-        }
-    }
-
-    /// Remove super peer
-    pub fn remove_super_peer(&mut self, peer: &PeerId) {
-        let super_peer = { self.super_peers.lock().as_mut().unwrap().remove(peer) };
-
-        if let Some(super_peer) = super_peer {
-            let event = Message::Text(JsonPeerEvent::PeerLeft(super_peer.id).to_string());
-            // Safety: Lock must be scoped/dropped to ensure no deadlock with loop
-            let super_peers = { self.super_peers.lock().unwrap().clone() };
-            super_peers.keys().for_each(
-            |peer_id| match self.try_send_to_super_peer(*peer_id, event.clone()) {
-                Ok(()) => info!("Sent peer remove to: {peer_id}"),                                      
-                Err(e) => error!("Failure sending peer remove: {e:?}"),
-                },
-            );
-
-            let children = super_peer.children.lock().unwrap();
-
-            children.iter().for_each(
-                |peer_id| match self.try_send_to_child_peer(*peer_id, event.clone()) {
-                    Ok(()) => info!("Sent peer remove to: {peer_id}"),                                      
-                    Err(e) => error!("Failure sending peer remove: {e:?}"),
-                },
-            );
-
-            if let Some(recruit_id) = children.iter().min(){ 
-
-                let recruit = { self.child_peers.lock().as_mut().unwrap().remove(recruit_id) };
-
-                if let Some(recruit) = recruit {
-                    self.add_super_peer(*recruit_id, recruit.signaling_channel);
-                    info!("added {recruit_id} as super peer");
-                    children.iter().for_each(
-                        |child_id| if child_id != recruit_id { 
-                            match self.connect_child(*child_id, *recruit_id) {
-                                Ok(()) => info!("redistributed {child_id} to {recruit_id}"),
-                                Err(e) => error!("Failure redistributing {child_id} to {recruit_id}: {e:?}")
-                            } 
+            // Remove the child from the map entirely
+            if let Some(child_peer) = peers.remove(&child_id) {
+                // Check if this peer was actually a Child
+                match child_peer.role {
+                    PeerRole::Child { parent_id: Some(pid) } => {
+                        // Remove this child from the parent's 'children' set
+                        if let Some(parent_peer) = peers.get_mut(&pid) {
+                            if let PeerRole::Super { children } = &mut parent_peer.role {
+                                children.remove(&child_id);
+                            }
                         }
-                    )
+                        // Parent will be notified after releasing the lock
+                        parent_id = Some(pid);
+                    }
+                    PeerRole::Child { parent_id: None } => {
+                        // It was a child with no parent; nothing else to do
+                        info!("Removed child peer {child_id} with no parent");
+                    }
+                    PeerRole::Super { .. } => {
+                        // The function name is remove_child_peer, but we found a Super?
+                        // Could log an error or handle differently:
+                        error!("Peer {child_id} was actually a super peer, not a child");
+                    }
+                }
+            } else {
+                // The child_id wasn't in the map
+                error!("Peer {child_id} was not found in peers map");
+                return;
+            }
+        } // <-- The lock is dropped here
+
+        // Now notify the parent (if any) without holding the lock
+        if let Some(pid) = parent_id {
+            let event = Message::Text(JsonPeerEvent::PeerLeft(child_id).to_string());
+            match self.try_send_to_peer(pid, event) {
+                Ok(()) => info!("Notified parent {pid} of child peer {child_id} removal"),
+                Err(e) => error!("Failed to notify parent {pid} of child removal: {e:?}"),
+            }
+        }
+    }
+
+    pub fn remove_super_peer(&mut self, super_id: PeerId) {
+        // We will gather the children of the removed super peer here.
+        let mut former_children: HashSet<PeerId> = HashSet::new();
+        // We'll also gather the IDs of the other super peers to notify.
+        let mut other_super_ids: Vec<PeerId> = Vec::new();
+
+        {
+            // 1) Lock the peers map and remove this super peer.
+            let mut peers_map = self.peers.lock().unwrap();
+
+            let maybe_super_peer = peers_map.remove(&super_id);
+            if let Some(removed_peer) = maybe_super_peer {
+                match removed_peer.role {
+                    // If this really was a super peer, capture its children.
+                    PeerRole::Super { children } => {
+                        former_children = children;
+
+                        // Gather all other super peer IDs (to tell them that `super_id` left).
+                        other_super_ids = peers_map
+                            .values()
+                            .filter(|p| matches!(p.role, PeerRole::Super { .. }))
+                            .map(|p| p.id)
+                            .collect();
+                    }
+                    // If we discovered it wasn’t actually a super peer, log an error (or handle differently).
+                    _ => {
+                        error!("Peer {super_id} was not actually a super peer!");
+                        // Possibly re‐insert it if that was unexpected:
+                        // peers_map.insert(super_id, removed_peer);
+                        return;
+                    }
+                }
+            } else {
+                error!("Tried removing unknown super peer {super_id}");
+                return;
+            }
+        } // <-- lock is dropped here
+
+        // 2) Notify other super peers that `super_id` left.
+        let event = Message::Text(JsonPeerEvent::PeerLeft(super_id).to_string());
+        for sp_id in &other_super_ids {
+            if let Err(e) = self.try_send_to_peer(*sp_id, event.clone()) {
+                error!("Failed to send PeerLeft({super_id}) to super peer {sp_id}: {e:?}");
+            }
+        }
+
+        // 3) Notify the children that their super peer is gone.
+        for &child_id in &former_children {
+            if let Err(e) = self.try_send_to_peer(child_id, event.clone()) {
+                error!("Failed to send PeerLeft({super_id}) to child {child_id}: {e:?}");
+            }
+        }
+
+        // 4) (Optional) “Promote” one of the children to be the new super peer.
+        //    You can pick the smallest ID, or any other selection strategy.
+        if let Some(&recruit_id) = former_children.iter().min() {
+            // Turn `recruit_id` into a super peer in place, then re‐attach the other children to it.
+            // We do so in a new scope, so the lock is short‐lived.
+            {
+                let mut peers_map = self.peers.lock().unwrap();
+
+                // If the recruit still exists in the map, update it.
+                if let Some(recruit) = peers_map.get_mut(&recruit_id) {
+                    // If it was a child, clear its parent and set it to super.
+                    match &mut recruit.role {
+                        PeerRole::Child { parent_id } => {
+                            *parent_id = None; // no parent now
+                        }
+                        // If it’s already a super, or something else, we might handle differently
+                        _ => {}
+                    }
+                    // Now make it a super with an empty children set, 
+                    // or you might directly insert the “former_children minus itself.”
+                    recruit.role = PeerRole::Super {
+                        children: HashSet::new(),
+                    };
+                } else {
+                    error!("Recruit peer {recruit_id} was not found in the map");
+                }
+            } // lock dropped
+
+            info!("Promoted peer {recruit_id} to super peer");
+
+            // 5) Re‐attach the other children to the new super peer
+            for &child_id in &former_children {
+                if child_id != recruit_id {
+                    if let Err(e) = self.connect_child(child_id, recruit_id) {
+                        error!("Failed to connect child {child_id} to new super {recruit_id}: {e:?}");
+                    }
                 }
             }
         }
-        
     }
 
-    /// Send signaling message to super peer
-    pub fn try_send_to_super_peer(&self, peer: PeerId, message: Message) -> Result<(), SignalingError> {
-        self.super_peers
-            .lock()
-            .as_mut()
-            .unwrap()
-            .get(&peer)
-            .ok_or_else(|| SignalingError::UnknownPeer)
-            .and_then(|sender| try_send(&sender.signaling_channel, message))
-        
-    }
-
-    /// Send signaling message to child peer
-    pub fn try_send_to_child_peer(&self, peer: PeerId, message: Message) -> Result<(), SignalingError> {
-        self.child_peers
+    /// Send signaling message to peer
+    pub fn try_send_to_peer(&self, peer: PeerId, message: Message) -> Result<(), SignalingError> {
+        self.peers
             .lock()
             .as_mut()
             .unwrap()
@@ -213,4 +363,10 @@ impl HybridState {
             .ok_or_else(|| SignalingError::UnknownPeer)
             .and_then(|sender| try_send(&sender.signaling_channel, message))      
     }
+
+    // demote_super_peer(&mut self, peer: &PeerId)
+
+    // promote_child_peer(&mut self, peer: &PeerId, children: Vec<PeerId>)
+
+    // 
 }

--- a/matchbox_server_hybrid/src/state.rs
+++ b/matchbox_server_hybrid/src/state.rs
@@ -20,7 +20,7 @@ pub enum PeerRole {
     },
 }
 
-/// A single “Peer” type that can be either a child or super peer.
+/// A single Peer type that can be either a child or super peer.
 #[derive(Debug)]
 pub struct Peer {
     /// The peer’s unique ID.
@@ -52,14 +52,9 @@ impl Peer {
         }
     }
     
-    /// Returns `true` if this peer is a super peer.
+    /// Returns true if this peer is a super peer.
     pub fn is_super(&self) -> bool {
         matches!(self.role, PeerRole::Super { .. })
-    }
-
-    /// Returns `true` if this peer is a child peer.
-    pub fn is_child(&self) -> bool {
-        matches!(self.role, PeerRole::Child { .. })
     }
 }
 
@@ -71,25 +66,6 @@ pub struct HybridState {
 impl SignalingState for HybridState {}  
 
 impl HybridState {
-    // TODO: implement functions to be called in state machine logic
-
-    /// Get number of super peers connected
-    pub fn get_num_super_peers(&self) -> usize {
-        let peers = self.peers.lock().unwrap();
-        peers
-            .values()
-            .filter(|peer| matches!(peer.role, PeerRole::Super { .. }))
-            .count()
-    }
-
-    /// Get number of child peers connected
-    pub fn get_num_child_peers(&self) -> usize {
-        let peers = self.peers.lock().unwrap();
-        peers
-            .values()
-            .filter(|peer| matches!(peer.role, PeerRole::Child { .. }))
-            .count()
-    }
 
     /// Check if a given `PeerId` corresponds to a super peer
     pub fn is_super_peer(&self, peer_id: &PeerId) -> bool {
@@ -112,15 +88,25 @@ impl HybridState {
             .collect()
     }
 
-    /// Get all child peer IDs
-    pub fn get_child_peer_ids(&self) -> Vec<PeerId> {
-        self.peers
-            .lock()
-            .unwrap()
-            .values()
-            .filter(|peer| peer.is_child())
-            .map(|peer| peer.id)
-            .collect()
+    /// Check if a new super peer should be added based on the ratio of child to super peers
+    pub fn should_add_super_peer(&self, peer_ratio: usize) -> bool {
+        let peers = self.peers.lock().unwrap();
+
+        let (mut child_count, mut super_count) = (0usize, 0usize);
+
+        for peer in peers.values() {
+            match &peer.role {
+                PeerRole::Child { .. } => child_count += 1,
+                PeerRole::Super { .. } => super_count += 1,
+            }
+        }
+
+        if super_count == 0 {
+            return true;
+        }
+
+        let ratio = child_count as f64 / super_count as f64;
+        ratio >= peer_ratio as f64
     }
 
     /// Returns super peer with the least number of children then lowest ID
@@ -128,24 +114,19 @@ impl HybridState {
         let peers = self.peers.lock().unwrap();
         peers
             .values()
-            // Filter only super peers
             .filter(|peer| matches!(peer.role, PeerRole::Super { .. }))
-            // Among super peers, find the one with the smallest (children.len(), id)
             .min_by_key(|peer| {
                 match &peer.role {
                     PeerRole::Super { children } => (children.len(), peer.id),
                     _ => (usize::MAX, peer.id), 
                 }
             })
-            // Return the selected peer’s ID
             .map(|peer| peer.id)
     }
 
     /// Add a new super peer
     pub fn add_super_peer(&mut self, peer: PeerId, sender: SignalingChannel) {
-        // Alert all super peers of new super peer
         let event = Message::Text(JsonPeerEvent::NewPeer(peer).to_string());
-        // Safety: Lock must be scoped/dropped to ensure no deadlock with loop
         let super_peers = { self.get_super_peer_ids()};
 
         super_peers.iter().for_each(|peer_id| {
@@ -153,7 +134,7 @@ impl HybridState {
                 error!("error informing {peer_id} of new super peer {peer}: {e:?}");
             }
         });
-        // Safety: All prior locks in this method must be freed prior to this call
+        
         self.peers.lock().as_mut().unwrap().insert(peer, Peer::new_super(peer, sender));
     }
 
@@ -204,8 +185,8 @@ impl HybridState {
                     }
                 }
             }
-        }
-        // Safety: All prior locks in this method must be freed prior to this call
+        } // <-- The lock is dropped here
+
         let event = Message::Text(JsonPeerEvent::NewPeer(child_id).to_string());
         self.try_send_to_peer(super_id, event)
     }   
@@ -233,12 +214,10 @@ impl HybridState {
                         parent_id = Some(pid);
                     }
                     PeerRole::Child { parent_id: None } => {
-                        // It was a child with no parent; nothing else to do
                         info!("Removed child peer {child_id} with no parent");
                     }
                     PeerRole::Super { .. } => {
-                        // The function name is remove_child_peer, but we found a Super?
-                        // Could log an error or handle differently:
+                        peers.insert(child_id, child_peer);
                         error!("Peer {child_id} was actually a super peer, not a child");
                     }
                 }
@@ -260,34 +239,24 @@ impl HybridState {
     }
 
     pub fn remove_super_peer(&mut self, super_id: PeerId) {
-        // We will gather the children of the removed super peer here.
-        let mut former_children: HashSet<PeerId> = HashSet::new();
-        // We'll also gather the IDs of the other super peers to notify.
-        let mut other_super_ids: Vec<PeerId> = Vec::new();
-
+        let former_children: HashSet<PeerId>;
+        let other_super_ids: Vec<PeerId>;
         {
-            // 1) Lock the peers map and remove this super peer.
             let mut peers_map = self.peers.lock().unwrap();
 
-            let maybe_super_peer = peers_map.remove(&super_id);
-            if let Some(removed_peer) = maybe_super_peer {
+            if let Some(removed_peer) = peers_map.remove(&super_id) {
                 match removed_peer.role {
-                    // If this really was a super peer, capture its children.
                     PeerRole::Super { children } => {
                         former_children = children;
-
-                        // Gather all other super peer IDs (to tell them that `super_id` left).
                         other_super_ids = peers_map
                             .values()
                             .filter(|p| matches!(p.role, PeerRole::Super { .. }))
                             .map(|p| p.id)
                             .collect();
                     }
-                    // If we discovered it wasn’t actually a super peer, log an error (or handle differently).
                     _ => {
                         error!("Peer {super_id} was not actually a super peer!");
-                        // Possibly re‐insert it if that was unexpected:
-                        // peers_map.insert(super_id, removed_peer);
+                        peers_map.insert(super_id, removed_peer);
                         return;
                     }
                 }
@@ -297,7 +266,7 @@ impl HybridState {
             }
         } // <-- lock is dropped here
 
-        // 2) Notify other super peers that `super_id` left.
+        // Notify other super peers that `super_id` left.
         let event = Message::Text(JsonPeerEvent::PeerLeft(super_id).to_string());
         for sp_id in &other_super_ids {
             if let Err(e) = self.try_send_to_peer(*sp_id, event.clone()) {
@@ -305,15 +274,14 @@ impl HybridState {
             }
         }
 
-        // 3) Notify the children that their super peer is gone.
+        // Notify the children that their super peer is gone.
         for &child_id in &former_children {
             if let Err(e) = self.try_send_to_peer(child_id, event.clone()) {
                 error!("Failed to send PeerLeft({super_id}) to child {child_id}: {e:?}");
             }
         }
 
-        // 4) (Optional) “Promote” one of the children to be the new super peer.
-        //    You can pick the smallest ID, or any other selection strategy.
+        // Promote one of the children to be the new super peer.
         if let Some(&recruit_id) = former_children.iter().min() {
             // Turn `recruit_id` into a super peer in place, then re‐attach the other children to it.
             // We do so in a new scope, so the lock is short‐lived.
@@ -342,7 +310,7 @@ impl HybridState {
 
             info!("Promoted peer {recruit_id} to super peer");
 
-            // 5) Re‐attach the other children to the new super peer
+            // Re‐attach the other children to the new super peer
             for &child_id in &former_children {
                 if child_id != recruit_id {
                     if let Err(e) = self.connect_child(child_id, recruit_id) {
@@ -352,6 +320,140 @@ impl HybridState {
             }
         }
     }
+
+    /// Transfers child with min id from giver to receiever super peers
+    pub fn move_child(&mut self, giver_id: PeerId, receiver_id: PeerId){
+
+        let child_id = {
+
+            if let Some(giver) = self.peers.lock().unwrap().get_mut(&giver_id) {
+                match &mut giver.role {
+                    PeerRole::Super { children } => {
+                        let cid = children.iter().min().cloned();
+                        if cid.is_some() {
+                            children.remove(&cid.unwrap());
+                            cid.unwrap()
+                        }
+                        else {
+                            error!("peer {giver_id} has no children to give");
+                            return
+                        }
+                    }
+            
+                    _ => {
+                            error!("trying to move child from {giver_id} but they are not a super peer");
+                            return
+                    }
+                }
+            }
+            else {
+                error!("{giver_id} does not exist in the network");
+                return
+            }
+        };
+
+        let event = Message::Text(JsonPeerEvent::PeerLeft(child_id).to_string());
+        match self.try_send_to_peer(giver_id, event) {
+            Ok(()) => info!("Notified parent {giver_id} of child peer {child_id} removal"),
+            Err(e) => error!("Failed to notify parent {giver_id} of child removal: {e:?}"),
+        }
+    
+        let event = Message::Text(JsonPeerEvent::PeerLeft(giver_id).to_string());
+        match self.try_send_to_peer(child_id, event) {
+            Ok(()) => info!("Notified child {child_id} of parent {giver_id} disconnection"),
+            Err(e) => error!("Failed to notify child {child_id} of parent disconnection: {e:?}"),
+        }
+    
+        match self.connect_child(child_id, receiver_id) {
+            Ok(()) => info!("Connected child {child_id} to parent {giver_id}"),
+            Err(e) => error!("Failed to notify parent {giver_id} of child connection: {e:?}"),
+        }   
+    }
+
+    pub fn load_balance(&mut self) {
+
+        // Get list of super peers and their child counts
+        let mut super_info: Vec<(PeerId, usize)> = {
+            let peers = self.peers.lock().unwrap();
+            peers
+                .values()
+                .filter_map(|peer| {
+                    if let PeerRole::Super { children } = &peer.role {
+                        Some((peer.id, children.len()))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
+
+        // If there are less than 2 super peers, we can't balance
+        if super_info.len() < 2 {
+            return;
+        }
+
+        // Sort super peers by number of children
+        super_info.sort_by_key(|&(_id, child_count)| child_count);
+        
+        // Calculate the average number of children per super peer
+        let total_children: usize = super_info.iter().map(|(_, c)| c).sum();
+        let num_supers = super_info.len();
+        let average = total_children / num_supers;
+        let remainder = total_children % num_supers;
+
+        let mut num_moves = 0;
+
+        let mut target_info: Vec<(PeerId, usize, usize)> = Vec::new();
+
+        for n in 0..super_info.len() {
+            if n < remainder {
+                target_info.push((super_info[n].0, super_info[n].1, average + 1)); 
+            }
+            else {
+                target_info.push((super_info[n].0, super_info[n].1, average)); 
+            }
+        }
+
+        let mut overloaded_idx: Vec<usize> = Vec::new();
+        let mut underloaded_idx: Vec<usize> = Vec::new();
+
+        for n in 0..target_info.len() {
+            if target_info[n].1 > target_info[n].2 {
+                overloaded_idx.push(n);
+            }
+            else if target_info[n].1 < target_info[n].2{
+                underloaded_idx.push(n);
+            }
+        }
+
+        let mut i:usize= 0;
+        let mut j:usize = 0;
+        while i < overloaded_idx.len() && j < underloaded_idx.len() {
+            if target_info[overloaded_idx[i]].1 <= target_info[overloaded_idx[i]].2 {
+                i += 1;
+                continue;
+            }
+            if target_info[underloaded_idx[j]].1 >= target_info[underloaded_idx[j]].2 {
+                j += 1;
+                continue;
+            }
+
+            target_info[overloaded_idx[i]].1 -= 1;
+            target_info[underloaded_idx[j]].1 += 1;
+            self.move_child(target_info[overloaded_idx[i]].0, target_info[underloaded_idx[j]].0);
+            num_moves += 1;
+        }
+
+        info!("{num_moves} reassignments made in load balancing");
+
+    }
+    // TODO: Logic for super peer assignment according to bandwidth
+    //-------------------------------------------------------------------
+    // demote_super_peer(&mut self, peer: &PeerId)
+    // promote_child_peer(&mut self, peer: &PeerId, children: Vec<PeerId>)
+    // lowest_bandwidth_super_peer(&self)
+    // highest_bandwidth_child_peer(&self)
+    //-------------------------------------------------------------------
 
     /// Send signaling message to peer
     pub fn try_send_to_peer(&self, peer: PeerId, message: Message) -> Result<(), SignalingError> {
@@ -363,10 +465,4 @@ impl HybridState {
             .ok_or_else(|| SignalingError::UnknownPeer)
             .and_then(|sender| try_send(&sender.signaling_channel, message))      
     }
-
-    // demote_super_peer(&mut self, peer: &PeerId)
-
-    // promote_child_peer(&mut self, peer: &PeerId, children: Vec<PeerId>)
-
-    // 
 }

--- a/matchbox_server_hybrid/src/topology.rs
+++ b/matchbox_server_hybrid/src/topology.rs
@@ -5,13 +5,13 @@ use axum::extract::ws::Message;
 use futures::StreamExt;
 use matchbox_protocol::{JsonPeerEvent, PeerRequest};
 use matchbox_signaling::{
-    common_logic::parse_request, ClientRequestError, NoCallbacks, SignalingTopology, WsStateMeta,
+    common_logic::parse_request, ClientRequestError, NoCallbacks, SignalingTopology, WsStateMeta, 
 };
 use tracing::{error, info, warn};
 
-//const PEER_RATIO: usize = 4;
+pub const PEER_RATIO: usize = 4;
     
-/// A client server network topology
+/// A hybrid network topology
 #[derive(Debug, Default)]
 pub struct HybridTopology;
 
@@ -26,36 +26,26 @@ impl SignalingTopology<NoCallbacks, HybridState> for HybridTopology{
             ..
         } = upgrade;
 
-        // Implement state machine logic for hybrid architechture
-        // If there are no super peers
-        if state.get_num_super_peers() < 2 {
+        if state.should_add_super_peer(PEER_RATIO) {
+            //TODO: Implement logic to assign super peers based off bandwidth
+            //-----------------------------------------------------------------------------------
+            // If an existing child have higher bandwidth than new peer
+            //      Make that child a new super peer and make new peer a child peer, load balance
+            // Else
+            //      Make new peer a super peer, load balance
+            //-----------------------------------------------------------------------------------
             state.add_super_peer(peer_id, sender.clone());
+            state.load_balance();
             info!("Added super peer {peer_id}");
-            /* 
-        // If super peer to child peer ratio is greater than PEER_RATIO
-        } else if state.get_num_child_peers() / state.get_num_super_peers() >= PEER_RATIO {
-            // Compare this peer's bandwidth to all child peer bandwidths
-
-            // If this peer has more bandwidth than all child peers, add as super peer
-            // Rebalance child peers among super peers
-
-            // Else add highest bandwidth child peer as super peer
-            // Add this peer as child peer
-            // Rebalance child peers among super peers
-
-            state.add_super_peer(peer_id, sender.clone());
-            info!("Added super peer {peer_id}");
-        // New super peer not needed, add as child peer
-        */
         } else {
-            // Compare this peer's bandwidth to all super peer bandwidths
-
-            // If this peer has higher bandwidth than one super peer
-            // Add this peer as a super peer
-            // Transfer children of lowest bandwidth super peer to this peer
-            // Make lowest bandwidth super peer a child peer and connect to least loaded super peer
-
-            // Else add this peer as a child peer and connect to least loaded super peer
+            //TODO: Implement logic to handle new child peers based off bandwidth
+            //-----------------------------------------------------------------------------------
+            // If the new peer a better candidate for super peer than existing super peers
+            //      Replace worst existing super peer with new peer, transfer children to new peer
+            //      Add old super peer as child of least loaded super peer
+            // Else
+            //      Add new peer as  child of least loaded super peer
+            //-----------------------------------------------------------------------------------
             state.add_child_peer(peer_id, sender.clone());
             if let Some(parent) = state.find_least_loaded_super_peer() {
                 match state.connect_child(peer_id, parent) {
@@ -116,6 +106,8 @@ impl SignalingTopology<NoCallbacks, HybridState> for HybridTopology{
                         error!("error sending signal event: {e:?}");
                     }
                 }
+                // TODO: Add custom hybrid events
+                // PeerRequest::GetChildren
                 // PeerRequest::UpdateBandwidth
 
                 PeerRequest::KeepAlive => {
@@ -124,21 +116,22 @@ impl SignalingTopology<NoCallbacks, HybridState> for HybridTopology{
                 }
             }
         }
-
+        
+        // If we have reached here the peer is leaving the network
         if state.is_super_peer(&peer_id) {
-            // Is child peer to super peer ratio low?
-
-            // If so, remove super peer
-            // Rebalance child peers among super peers
-
-            // Else find child peer with highest bandwidth
-            // Make that child peer a super peer
-            // Transfer children of leaving super peer to new super peer
-            // Remove leaving super peer
+            // TODO: Implement dynamic super peer removal taking bandwidth into consideration
+            //-----------------------------------------------------------------------------------
+            // If child peer to super peer ratio low
+            //      Remove super peer and load balance
+            // Else 
+            //      Find child peer with highest bandwidth
+            //      Make that child peer a super peer
+            //      Transfer children of leaving super peer to new super peer
+            //      Remove leaving super peer
+            //-----------------------------------------------------------------------------------
             state.remove_super_peer(peer_id);
         } else {
             state.remove_child_peer(peer_id);
-            // Lifecycle event: On ChildPeer Disonnected
         }
         
     }
@@ -146,15 +139,33 @@ impl SignalingTopology<NoCallbacks, HybridState> for HybridTopology{
 
 #[cfg(test)]
 mod tests {
-    use futures::{SinkExt, StreamExt};
-    use matchbox_protocol::{JsonPeerEvent, PeerEvent, PeerId}; 
-    use matchbox_signaling::SignalingServer;
+    use futures::StreamExt;
+    use matchbox_protocol::{JsonPeerEvent, PeerId}; 
+    use matchbox_signaling::{SignalingServer, SignalingServerBuilder};
     use std::{net::Ipv4Addr, str::FromStr};
     use tokio::net::TcpStream;
     use tokio_tungstenite::{tungstenite::Message, MaybeTlsStream, WebSocketStream};
     use tracing::info;
 
-    // Helper to take the next PeerEvent from a stream
+    use crate::{state::HybridState, topology::PEER_RATIO};
+
+    use super::HybridTopology;
+
+    /// Helper to build hybrid signaling server
+    fn app() -> SignalingServer {
+        let state = HybridState::default();
+        SignalingServerBuilder::new((Ipv4Addr::LOCALHOST, 0), HybridTopology, state.clone())
+            .on_connection_request(|connection| {
+                info!("Connecting: {connection:?}");
+                Ok(true) // Allow all connections
+            })
+            .on_id_assignment(|(socket, id)| info!("{socket} received {id}"))
+            .cors()
+            .trace()
+            .build()
+    }
+
+    /// Helper to take the next PeerEvent from a stream
     async fn recv_peer_event(
         client: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
     ) -> JsonPeerEvent {
@@ -162,7 +173,7 @@ mod tests {
         JsonPeerEvent::from_str(&message.to_string()).expect("json peer event")
     }
 
-    // Helper to extract PeerId when expecting an Id assignment
+    /// Helper to extract PeerId when expecting an Id assignment
     fn get_peer_id(peer_event: JsonPeerEvent) -> PeerId {
         if let JsonPeerEvent::IdAssigned(id) = peer_event {
             id
@@ -170,10 +181,10 @@ mod tests {
             panic!("Peer_event was not IdAssigned: {peer_event:?}");
         }
     }
-
+    /// Testing peer can connect to signaling server
     #[tokio::test]
     async fn ws_connect() {
-        let mut server = SignalingServer::hybrid_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let mut server = app();
         let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
@@ -182,337 +193,222 @@ mod tests {
             .expect("handshake");
     }
 
-
-
+    /// Testing peer is assigned an id upon initial connection
     #[tokio::test]
     async fn uuid_assigned() {
-        let mut server = SignalingServer::hybrid_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let mut server = app();        
+        let addr = server.bind().unwrap();
+        tokio::spawn(server.serve());
+
+        let (mut peer, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
+            .await
+            .unwrap();
+
+        let id_assigned_event = recv_peer_event(&mut peer).await;
+
+        assert!(matches!(id_assigned_event, JsonPeerEvent::IdAssigned(..)));
+    }
+
+    /// Testing a super peer can make up to PEER_RATIO connections with connecting child peers
+    #[tokio::test]
+    async fn super_peer_gets_peer_ratio_children() {
+        let mut server = app(); 
         let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut super_peer, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
             .await
             .unwrap();
+        let _super_peer_uuid = get_peer_id(recv_peer_event(&mut super_peer).await);
 
-        let id_assigned_event = recv_peer_event(&mut super_peer).await;
+        let mut child_peers: Vec<(PeerId, WebSocketStream<MaybeTlsStream<TcpStream>>)> = Vec::new();
 
-        assert!(matches!(id_assigned_event, JsonPeerEvent::IdAssigned(..)));
-    }
-
-    #[tokio::test]
-    async fn multiple_super_peers() {
-        let mut server = SignalingServer::hybrid_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.bind().unwrap();
-        tokio::spawn(server.serve());
-
-        let (mut super_peer_a, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let _a_uuid = get_peer_id(recv_peer_event(&mut super_peer_a).await);
-
-        let (mut super_peer_b, _response) =
-            tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
+        for _ in 0..PEER_RATIO {
+            let (mut child_peer,  _response) =  tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
                 .await
                 .unwrap();
-        let b_uuid = get_peer_id(recv_peer_event(&mut super_peer_b).await);
+            let child_peer_uuid = get_peer_id(recv_peer_event(&mut child_peer).await);
 
-        let new_peer_event = recv_peer_event(&mut super_peer_a).await;
-
-        assert_eq!(new_peer_event, JsonPeerEvent::NewPeer(b_uuid));
-    }
-
-    #[tokio::test]
-    async fn connect_child_peer() {
-        let mut server = SignalingServer::hybrid_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.bind().unwrap();
-        tokio::spawn(server.serve());
-
-        let (mut super_peer_a, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let super_peer_a_uuid = get_peer_id(recv_peer_event(&mut super_peer_a).await);
-
-        let (mut super_peer_b, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let super_peer_b_uuid = get_peer_id(recv_peer_event(&mut super_peer_b).await);
-
-        let new_peer_event = recv_peer_event(&mut super_peer_a).await;
-
-        info!("Super peer a got: {new_peer_event}");
-
-        let (mut child_a, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let child_a_uuid = get_peer_id(recv_peer_event(&mut child_a).await);
-
-        let new_peer_event: PeerEvent<serde_json::Value>;
-
-        if super_peer_a_uuid < super_peer_b_uuid {
-            new_peer_event = recv_peer_event(&mut super_peer_a).await;
-        }
-        else {
-            new_peer_event = recv_peer_event(&mut super_peer_b).await;
+            child_peers.push((child_peer_uuid, child_peer));
         }
 
-        assert_eq!(new_peer_event, JsonPeerEvent::NewPeer(child_a_uuid));
+            
+        let mut received_new_peers: Vec<PeerId> = Vec::new();
+        while received_new_peers.len() < PEER_RATIO {
+            let event = recv_peer_event(&mut super_peer).await;
 
-    
-        let (mut child_b, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let child_b_uuid = get_peer_id(recv_peer_event(&mut child_b).await);
-
-        let new_peer_event:PeerEvent<serde_json::Value>;
-
-        if super_peer_a_uuid < super_peer_b_uuid {
-            new_peer_event = recv_peer_event(&mut super_peer_b).await;
-        }
-        else {
-            new_peer_event = recv_peer_event(&mut super_peer_a).await;
-        }
-
-        assert_eq!(new_peer_event, JsonPeerEvent::NewPeer(child_b_uuid));
-
-    }
-
-    #[tokio::test]
-    async fn disconnect_child_peer() {
-        let mut server = SignalingServer::hybrid_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.bind().unwrap();
-        tokio::spawn(server.serve());
-
-        let (mut super_peer_a, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let super_peer_a_uuid = get_peer_id(recv_peer_event(&mut super_peer_a).await);
-
-        let (mut super_peer_b, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let super_peer_b_uuid = get_peer_id(recv_peer_event(&mut super_peer_b).await);
-
-        recv_peer_event(&mut super_peer_a).await;
-
-        let (mut child_a, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-        .await
-        .unwrap();
-        let child_a_uuid = get_peer_id(recv_peer_event(&mut child_a).await);
-
-        let new_peer_event: PeerEvent<serde_json::Value>;
-
-        if super_peer_a_uuid < super_peer_b_uuid {
-            new_peer_event = recv_peer_event(&mut super_peer_a).await;
-        }
-        else {
-            new_peer_event = recv_peer_event(&mut super_peer_b).await;
-        }
-
-        assert_eq!(new_peer_event, JsonPeerEvent::NewPeer(child_a_uuid));
-
-        _ = child_a.close(None).await;
-        let peer_left_event: PeerEvent<serde_json::Value>;
-
-        if super_peer_a_uuid < super_peer_b_uuid {
-            peer_left_event = recv_peer_event(&mut super_peer_a).await;
-        }
-        else {
-            peer_left_event = recv_peer_event(&mut super_peer_b).await;
-        }
-
-        assert_eq!(peer_left_event, JsonPeerEvent::PeerLeft(child_a_uuid));
-
-    }
-
-   #[tokio::test]
-    async fn disconnect_super_peer_no_children() {
-        let mut server = SignalingServer::hybrid_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.bind().unwrap();
-        tokio::spawn(server.serve());
-
-        let (mut super_peer_a, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let super_peer_a_uuid = get_peer_id(recv_peer_event(&mut super_peer_a).await);
-
-        let (mut super_peer_b, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let _super_peer_b_uuid = get_peer_id(recv_peer_event(&mut super_peer_b).await);
-
-        recv_peer_event(&mut super_peer_a).await;
-
-        _ = super_peer_a.close(None).await;
-        let peer_left_event = recv_peer_event(&mut super_peer_b).await;
-
-        assert_eq!(peer_left_event, JsonPeerEvent::PeerLeft(super_peer_a_uuid));
-
-    }
-
-    #[tokio::test]
-    async fn disconnect_super_peer_with_children() {
-        let mut server = SignalingServer::hybrid_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.bind().unwrap();
-        tokio::spawn(server.serve());
-
-        let (mut super_peer_a, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let super_peer_a_uuid = get_peer_id(recv_peer_event(&mut super_peer_a).await);
-
-        let (mut super_peer_b, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let super_peer_b_uuid = get_peer_id(recv_peer_event(&mut super_peer_b).await);
-
-        recv_peer_event(&mut super_peer_a).await;
-
-        let (mut child_a, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-        .await
-        .unwrap();
-        let child_a_uuid = get_peer_id(recv_peer_event(&mut child_a).await);
-
-        if super_peer_a_uuid < super_peer_b_uuid {
-            recv_peer_event(&mut super_peer_a).await;
-            _ = super_peer_a.close(None).await;
-            assert_eq!(recv_peer_event(&mut super_peer_b).await, JsonPeerEvent::PeerLeft(super_peer_a_uuid));
-            assert_eq!(recv_peer_event(&mut child_a).await, JsonPeerEvent::PeerLeft(super_peer_a_uuid));
-            assert_eq!(recv_peer_event(&mut super_peer_b).await, JsonPeerEvent::NewPeer(child_a_uuid));
-
-        }
-        else {
-            recv_peer_event(&mut super_peer_b).await;
-            _ = super_peer_b.close(None).await;
-            assert_eq!(recv_peer_event(&mut super_peer_a).await, JsonPeerEvent::PeerLeft(super_peer_b_uuid));
-            assert_eq!(recv_peer_event(&mut child_a).await, JsonPeerEvent::PeerLeft(super_peer_b_uuid));
-            assert_eq!(recv_peer_event(&mut super_peer_a).await, JsonPeerEvent::NewPeer(child_a_uuid));
-        }
-    }
-
-    #[tokio::test] 
-    async fn reassigning_children() {
-        let mut server = SignalingServer::hybrid_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.bind().unwrap();
-        tokio::spawn(server.serve());
-
-        let (mut super_peer_a, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let super_peer_a_uuid = get_peer_id(recv_peer_event(&mut super_peer_a).await);
-
-        let (mut super_peer_b, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-        let super_peer_b_uuid = get_peer_id(recv_peer_event(&mut super_peer_b).await);
-
-        recv_peer_event(&mut super_peer_a).await;
-
-        let (mut child_a, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-        .await
-        .unwrap();
-        let child_a_uuid = get_peer_id(recv_peer_event(&mut child_a).await);
-
-        if super_peer_a_uuid < super_peer_b_uuid {
-            assert_eq!(recv_peer_event(&mut super_peer_a).await, JsonPeerEvent::NewPeer(child_a_uuid));
-
-            let (mut child_b, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-            let child_b_uuid = get_peer_id(recv_peer_event(&mut child_b).await);
-            assert_eq!(recv_peer_event(&mut super_peer_b).await, JsonPeerEvent::NewPeer(child_b_uuid));
-
-            let (mut child_c, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-            let child_c_uuid = get_peer_id(recv_peer_event(&mut child_c).await);
-            assert_eq!(recv_peer_event(&mut super_peer_a).await, JsonPeerEvent::NewPeer(child_c_uuid));
-
-            _ = super_peer_a.close(None).await;
-
-            if child_a_uuid < child_c_uuid {
-                assert_eq!(recv_peer_event(&mut child_a).await, JsonPeerEvent::PeerLeft(super_peer_a_uuid));
-                assert_eq!(recv_peer_event(&mut child_c).await, JsonPeerEvent::PeerLeft(super_peer_a_uuid));
-                assert_eq!(recv_peer_event(&mut super_peer_b).await, JsonPeerEvent::PeerLeft(super_peer_a_uuid));
-                assert_eq!(recv_peer_event(&mut super_peer_b).await, JsonPeerEvent::NewPeer(child_a_uuid));
-                assert_eq!(recv_peer_event(&mut child_a).await, JsonPeerEvent::NewPeer(child_c_uuid));
-            }
-            else{
-                assert_eq!(recv_peer_event(&mut child_a).await, JsonPeerEvent::PeerLeft(super_peer_a_uuid));
-                assert_eq!(recv_peer_event(&mut child_c).await, JsonPeerEvent::PeerLeft(super_peer_a_uuid));
-                assert_eq!(recv_peer_event(&mut super_peer_b).await, JsonPeerEvent::PeerLeft(super_peer_a_uuid));
-                assert_eq!(recv_peer_event(&mut super_peer_b).await, JsonPeerEvent::NewPeer(child_c_uuid));
-                assert_eq!(recv_peer_event(&mut child_c).await, JsonPeerEvent::NewPeer(child_a_uuid));
+            match event {
+                JsonPeerEvent::NewPeer(peer_id) => received_new_peers.push(peer_id),
+                _ => assert!(false),
             }
         }
-        else {
-            assert_eq!(recv_peer_event(&mut super_peer_b).await, JsonPeerEvent::NewPeer(child_a_uuid));
 
-            let (mut child_b, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-            let child_b_uuid = get_peer_id(recv_peer_event(&mut child_b).await);
-            assert_eq!(recv_peer_event(&mut super_peer_a).await, JsonPeerEvent::NewPeer(child_b_uuid));
+        let expected: std::collections::HashSet<_> = child_peers.into_iter().map(|(id, _)| id).collect();
+        let actual: std::collections::HashSet<_> = received_new_peers.into_iter().collect();
 
-            let (mut child_c, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
-            .await
-            .unwrap();
-            let child_c_uuid = get_peer_id(recv_peer_event(&mut child_c).await);
-            assert_eq!(recv_peer_event(&mut super_peer_b).await, JsonPeerEvent::NewPeer(child_c_uuid));
-
-            _ = super_peer_b.close(None).await;
-
-            if child_a_uuid < child_c_uuid {
-                assert_eq!(recv_peer_event(&mut child_a).await, JsonPeerEvent::PeerLeft(super_peer_b_uuid));
-                assert_eq!(recv_peer_event(&mut child_c).await, JsonPeerEvent::PeerLeft(super_peer_b_uuid));
-                assert_eq!(recv_peer_event(&mut super_peer_a).await, JsonPeerEvent::PeerLeft(super_peer_b_uuid));
-                assert_eq!(recv_peer_event(&mut super_peer_a).await, JsonPeerEvent::NewPeer(child_a_uuid));
-                assert_eq!(recv_peer_event(&mut child_a).await, JsonPeerEvent::NewPeer(child_c_uuid));
-            }
-            else {
-                assert_eq!(recv_peer_event(&mut child_a).await, JsonPeerEvent::PeerLeft(super_peer_b_uuid));
-                assert_eq!(recv_peer_event(&mut child_c).await, JsonPeerEvent::PeerLeft(super_peer_b_uuid));
-                assert_eq!(recv_peer_event(&mut super_peer_a).await, JsonPeerEvent::PeerLeft(super_peer_b_uuid));
-                assert_eq!(recv_peer_event(&mut super_peer_a).await, JsonPeerEvent::NewPeer(child_c_uuid));
-                assert_eq!(recv_peer_event(&mut child_c).await, JsonPeerEvent::NewPeer(child_a_uuid));
-            }  
-        }
+        assert_eq!(expected, actual, "Super peer did not receive all child's NewPeer events");
     }
+
+    /// Testing that upon the connection of a second super peer, existing children in the network are spread evenly
     #[tokio::test]
-    async fn signal() {
-        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
+    async fn new_super_peer_then_rebalance() {
+        let mut server = app(); 
         let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
-        let (mut host, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
+        let (mut super_peer_a, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
             .await
             .unwrap();
-        let _host_uuid = get_peer_id(recv_peer_event(&mut host).await);
+        let _super_peer_a_uuid = get_peer_id(recv_peer_event(&mut super_peer_a).await);
 
-        let (mut client_a, _response) =
-            tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
+        let mut child_peers: Vec<WebSocketStream<MaybeTlsStream<TcpStream>>> = Vec::new();
+
+        for _ in 0..PEER_RATIO {
+            let (mut child_peer,  _response) =  tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
                 .await
                 .unwrap();
-        let a_uuid = get_peer_id(recv_peer_event(&mut client_a).await);
+            let _child_peer_uuid = get_peer_id(recv_peer_event(&mut child_peer).await);
 
-        let new_peer_event = recv_peer_event(&mut host).await;
-        let peer_uuid = match new_peer_event {
-            JsonPeerEvent::NewPeer(PeerId(peer_uuid)) => peer_uuid.to_string(),
-            _ => panic!("unexpected event"),
-        };
+            child_peers.push(child_peer);
+        }
 
-        _ = client_a
-            .send(Message::text(format!(
-                "{{\"Signal\": {{\"receiver\": \"{peer_uuid}\", \"data\": \"123\" }}}}"
-            )))
-            .await;
+            
+        let mut received_new_peers: Vec<PeerId> = Vec::new();
+        while received_new_peers.len() < PEER_RATIO {
+            let event = recv_peer_event(&mut super_peer_a).await;
 
-        let signal_event = recv_peer_event(&mut host).await;
-        assert_eq!(
-            signal_event,
-            JsonPeerEvent::Signal {
-                data: serde_json::Value::String("123".to_string()),
-                sender: a_uuid,
+            match event {
+                JsonPeerEvent::NewPeer(peer_id) => received_new_peers.push(peer_id),
+                _ => assert!(false),
+            } 
+        }
+
+        let (mut super_peer_b, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
+            .await
+            .unwrap();
+        let super_peer_b_uuid = get_peer_id(recv_peer_event(&mut super_peer_b).await);
+
+        let mut former_children: Vec<PeerId> = Vec::new();
+        while former_children.len() < PEER_RATIO / 2 {
+            let event = recv_peer_event(&mut super_peer_a).await;
+
+            match event {
+                JsonPeerEvent::PeerLeft(peer_id) => former_children.push(peer_id),
+                JsonPeerEvent::NewPeer(_) => assert_eq!(event, JsonPeerEvent::NewPeer(super_peer_b_uuid)),
+                _ => assert!(false),
             }
-        );
+        }
+ 
+        let mut new_children: Vec<PeerId> = Vec::new();
+        while new_children.len() < PEER_RATIO / 2 {
+            let event = recv_peer_event(&mut super_peer_b).await;
+            match event {
+                JsonPeerEvent::NewPeer(peer_id) => new_children.push(peer_id),
+                _ => assert!(false),
+            }
+        }
+
+        let super_peer_a_left_children: std::collections::HashSet<_> = former_children.into_iter().collect();
+        let super_peer_b_joined_children: std::collections::HashSet<_> = new_children.into_iter().collect();
+
+        assert_eq!(super_peer_a_left_children, super_peer_b_joined_children, "Children were not transfered correctly");
+    }
+
+    /// Testing that a child can smoothly disconnect from the network
+    #[tokio::test]
+    async fn child_peer_disconnecting() {
+        let mut server = app(); 
+        let addr = server.bind().unwrap();
+        tokio::spawn(server.serve());
+
+        let (mut super_peer, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
+            .await
+            .unwrap();
+        let _super_peer_uuid = get_peer_id(recv_peer_event(&mut super_peer).await);
+
+        let (mut child_peer,  _response) =  tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
+            .await
+            .unwrap();
+        let child_peer_uuid = get_peer_id(recv_peer_event(&mut child_peer).await);
+
+        let event = recv_peer_event(&mut super_peer).await;
+
+        assert_eq!(event, JsonPeerEvent::NewPeer(child_peer_uuid));
+
+        let _ = child_peer.close(None).await;
+
+        let event = recv_peer_event(&mut super_peer).await;
+
+        assert_eq!(event, JsonPeerEvent::PeerLeft(child_peer_uuid));
+    }
+
+    /// Testing that a super peer can smoothly disconnect from the network and have one of its children be promoted to take its place
+    #[tokio::test]
+    async fn super_peer_disconnecting() {
+        let mut server = app(); 
+        let addr = server.bind().unwrap();
+        tokio::spawn(server.serve());
+
+        let (mut super_peer, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
+            .await
+            .unwrap();
+        let super_peer_uuid = get_peer_id(recv_peer_event(&mut super_peer).await);
+
+        let mut child_peers: Vec<(PeerId, WebSocketStream<MaybeTlsStream<TcpStream>>)> = Vec::new();
+
+        for _ in 0..PEER_RATIO {
+            let (mut child_peer,  _response) =  tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
+                .await
+                .unwrap();
+            let child_peer_uuid = get_peer_id(recv_peer_event(&mut child_peer).await);
+
+            child_peers.push((child_peer_uuid, child_peer));
+        }
+ 
+        for _ in 0..PEER_RATIO {
+            let event = recv_peer_event(&mut super_peer).await;
+
+            match event {
+                JsonPeerEvent::NewPeer(_) => {} ,
+                _ => assert!(false),
+            }
+        }
+
+        let _ = super_peer.close(None).await;
+
+        for i in 0..PEER_RATIO {
+            let event = recv_peer_event(&mut child_peers[i].1).await;
+
+            match event {
+                JsonPeerEvent::PeerLeft(id) => assert_eq!(id, super_peer_uuid) ,
+                _ => assert!(false),
+            }
+        }
+
+        let mut new_children: Vec<PeerId> = Vec::new();
+        let mut new_super_peer = child_peers[0].0;
+        let mut index = 0;
+        for i in 1..PEER_RATIO {
+            if child_peers[i].0 < new_super_peer{
+                new_super_peer = child_peers[i].0;
+                index = i;
+            }
+        }
+
+        let mut new_super_peer = child_peers.remove(index);
+        while new_children.len() < PEER_RATIO - 1 {
+            let event = recv_peer_event(&mut new_super_peer.1).await;
+
+            match event {
+                JsonPeerEvent::NewPeer(id) => new_children.push(id),
+                _ => assert!(false),
+            }
+        }
+
+        let expected: std::collections::HashSet<_> = child_peers.into_iter().map(|(id, _)| id).collect();
+        let actual: std::collections::HashSet<_> = new_children.into_iter().collect();
+
+        assert_eq!(expected, actual);
     }
 }
+

--- a/matchbox_server_hybrid/src/topology.rs
+++ b/matchbox_server_hybrid/src/topology.rs
@@ -27,12 +27,13 @@ impl SignalingTopology<NoCallbacks, HybridState> for HybridTopology{
         // Implement state machine logic for hybrid architechture
         if state.get_num_super_peers() < 2 {
             state.add_super_peer(peer_id, sender.clone());
+            info!("Added super peer {peer_id}");
         } else {
             state.add_child_peer(peer_id, sender.clone());
             if let Some(parent) = state.find_super_peer() {
                 match state.connect_child(peer_id, parent) {
                     Ok(_) => {
-                        info!("Connected {peer_id} to {parent}");
+                        info!("Connected CHILD:{peer_id} to PARENT:{parent}");
                     }
                     Err(e) => {
                         error!("error sending peer {peer_id} to super: {e:?}");


### PR DESCRIPTION
Super peers are not statically assigned anymore. An ideal peer ratio is given as a constant and the signaling server uses that value to determine whether or not it should assign more super peers.